### PR TITLE
Remove the package-metadata.json file.

### DIFF
--- a/package-metadata.json
+++ b/package-metadata.json
@@ -1,1 +1,0 @@
-{"platforms": ["*"], "version": "5.2.0", "dependencies": [], "description": "The most hackable theme for Sublime Text 3", "url": "https://github.com/ihodev/sublime-boxy", "sublime_text": ">=3103"}


### PR DESCRIPTION
The package-metadata.json file is not meant to be committed into source control. It is generated by Package Control to identify packages that it manages, and ended up committed when this repository was populated from the installed state of the package.

Fixes #1.
